### PR TITLE
Testing for codegen + minor cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ license = "GPLv3"
 readme = "README.md"
 edition = "2021"
 
+[lib]
+path = "lib/src/lib.rs"
+test = true
+crate-type = ["lib"]
+
 [dependencies]
 color-eyre = "0.6.2"
 tracing = "0.1.37"

--- a/lib/src/codegen/ir.rs
+++ b/lib/src/codegen/ir.rs
@@ -321,7 +321,6 @@ fn generate_method(
         name: method.name.clone(),
         max_stack: 0,
         code: vec![],
-        return_type: method.ret_type.clone(),
     };
 
     compiled_method.code.append(&mut generate_code_stmt(

--- a/lib/src/codegen/ir.rs
+++ b/lib/src/codegen/ir.rs
@@ -215,7 +215,13 @@ impl CompiledMethod {
         );
         // TODO: Attributes count and attributes
 
-        vec![] // TODO: Replace with actual return value
+        result
+    }
+
+    fn as_bytes(&self, constant_pool: &mut ConstantPool) -> Vec<u8> {
+        let mut result = vec![];
+        // TODO
+        result
     }
 }
 

--- a/lib/src/parser/parser.rs
+++ b/lib/src/parser/parser.rs
@@ -9,7 +9,7 @@ use pest_derive::Parser;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]
-#[grammar = "src/parser/ExampleGrammar.pest"]
+#[grammar = "../lib/src/parser/ExampleGrammar.pest"]
 struct ExampleParser;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/src/tests/while_class.rs
+++ b/lib/src/tests/while_class.rs
@@ -90,7 +90,7 @@ fn while_class() -> Class {
                                                 "a".to_string(),
                                                 TypedExpr(
                                                     Box::new(Binary(
-                                                        "*".to_string(),
+                                                        "+".to_string(),
                                                         Box::new(TypedExpr(
                                                             Box::new(LocalOrFieldVar(
                                                                 "a".to_string(),

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -2,7 +2,7 @@ use crate::codegen::ConstantPool;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Class {
     pub name: String,
     pub fields: Vec<FieldDecl>,
@@ -37,7 +37,7 @@ impl Default for Class {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct FieldDecl {
     pub field_type: Type,
     pub name: String,

--- a/lib/testcases/ArithmeticMethods-expected.java
+++ b/lib/testcases/ArithmeticMethods-expected.java
@@ -1,0 +1,16 @@
+class ArithmeticMethods {
+	int x = 69;
+	int y = 420;
+	int addX(int a) {
+		return (x) + (a);
+	}
+	int addY(int a) {
+		return (y) + (a);
+	}
+	int complexMath(int a, int b) {
+		a = ((y) * ((a) + (b))) / (x);
+		b = (a) + (-(b));
+		a = (x) + ((b) * (a));
+		return (x) * (a);
+	}
+}

--- a/lib/testcases/AssignedFields-expected.java
+++ b/lib/testcases/AssignedFields-expected.java
@@ -1,0 +1,7 @@
+class AssignedFields {
+	int x = 69;
+	char c = 'x';
+	String s = "Hello World";
+	String stringsCanBeNull = null;
+	boolean b = true;
+}

--- a/lib/testcases/BoolAlg-expected.java
+++ b/lib/testcases/BoolAlg-expected.java
@@ -1,0 +1,5 @@
+class BoolAlg {
+	boolean f(boolean a, boolean b, boolean c) {
+		return ((a) && (b)) || (c);
+	}
+}

--- a/lib/testcases/ComplexIf-expected.java
+++ b/lib/testcases/ComplexIf-expected.java
@@ -1,0 +1,25 @@
+class ComplexIf {
+	boolean f(char c) {
+		if ((c) == ('a')) {
+			return true;
+		} else {
+			if ((c) == ('b')) {
+				return false;
+			} else {
+				if ((c) == ('c')) {
+					return true;
+				} else {
+					if (((c) == ('d')) || ((c) == ('e'))) {
+						return false;
+					} else {
+						if (((c) == ('f')) && ((c) == ('g'))) {
+							return true;
+						} else {
+							return false;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/lib/testcases/Empty-expected.java
+++ b/lib/testcases/Empty-expected.java
@@ -1,0 +1,2 @@
+class Empty {
+}

--- a/lib/testcases/EmptyMethod-expected.java
+++ b/lib/testcases/EmptyMethod-expected.java
@@ -1,0 +1,4 @@
+class emptyMethod {
+	void f() {
+	}
+}

--- a/lib/testcases/Fib-expected.java
+++ b/lib/testcases/Fib-expected.java
@@ -1,0 +1,28 @@
+class Fib {
+	int rec(int n) {
+		if ((n) < (2)) {
+			return n;
+		} else {
+			return (this.rec((n) - (1))) + (this.rec((n) - (2)));
+		}
+	}
+	int iter(int n) {
+		if ((n) < (2)) {
+			return n;
+		}
+		int x;
+		x = 0;
+		int y;
+		y = 1;
+		int i;
+		i = 1;
+		while ((i) < (n)) {
+			int next;
+			next = (y) + (x);
+			x = y;
+			y = next;
+			i = (i) + (1);
+		}
+		return y;
+	}
+}

--- a/lib/testcases/Fields-expected.java
+++ b/lib/testcases/Fields-expected.java
@@ -1,0 +1,6 @@
+class Fields {
+	int x;
+	boolean b;
+	char c;
+	String s;
+}

--- a/lib/testcases/If-expected.java
+++ b/lib/testcases/If-expected.java
@@ -1,0 +1,8 @@
+class If {
+	boolean f(char c) {
+		if ((c) == ('a')) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/lib/testcases/IntFields-expected.java
+++ b/lib/testcases/IntFields-expected.java
@@ -1,0 +1,4 @@
+class IntFields {
+	int x;
+	int y;
+}

--- a/lib/testcases/LocalVarDecl-expected.java
+++ b/lib/testcases/LocalVarDecl-expected.java
@@ -1,0 +1,7 @@
+class LocalVarDecl {
+	int f() {
+		int x;
+		x = 69;
+		return x;
+	}
+}

--- a/lib/testcases/MethodCall-expected.java
+++ b/lib/testcases/MethodCall-expected.java
@@ -1,0 +1,11 @@
+class MethodCall {
+	String world() {
+		return "World";
+	}
+	String hello() {
+		return "Hello";
+	}
+	String f() {
+		return (this.hello()) + ((" ") + (this.world()));
+	}
+}

--- a/lib/testcases/Test.java
+++ b/lib/testcases/Test.java
@@ -1,0 +1,9 @@
+class Test {
+public static void main(String[] args) {
+While m = new While();
+System.out.println(m.f(5));
+System.out.println(m.f(5));
+System.out.println(m.f(5));
+System.out.println(m.f(5));
+System.out.println(m.f(5));
+}}

--- a/lib/testcases/While-expected.java
+++ b/lib/testcases/While-expected.java
@@ -1,0 +1,14 @@
+class While {
+	int n = 2;
+	int f(int x) {
+		int i;
+		i = 0;
+		int a;
+		a = n;
+		while ((i) < (x)) {
+			a = (a) + (a);
+			i = (i) + (1);
+		}
+		return a;
+	}
+}

--- a/lib/testcases/While.java
+++ b/lib/testcases/While.java
@@ -5,7 +5,7 @@ class While {
 		int i = 0;
 		int a = n;
 		while (i < x) {
-			a = a * a;
+			a = a + a;
 			i = i + 1;
 		}
 		return a;


### PR DESCRIPTION
I added testing for codegen. The way it works, is that I create another java file (called Test.java) which has a main method from which I call methods from the java file that we actually want to test. I then run this once with the orginal java code (for the expected result) and once with the binary class file that you create in the codegen.

The only other option for testing the codegen, that I can think of, would be to manually write the expected DIR and then compare that with your result. We can do that too, if you prefer, but that would be quite a bit more work of course xd.

I also cleaned up some stuff in my testing code. And lastly I changed one important thing in the Cargo.toml (I added a [lib] section). The benefit of that, is that we can run `cargo test --lib` from the root directory now. Before that, I at least always had to first go into the lib directory and then call `cargo test` from there.